### PR TITLE
Dont rename the report

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/qftest/QFTestConfigBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/qftest/QFTestConfigBuilder.java
@@ -329,7 +329,6 @@ public class QFTestConfigBuilder extends Builder implements SimpleBuildStep
 			int nReports = args.addSuiteConfig(qrzdir, rl);
 			if (nReports > 0) {
 				startQFTestProc.apply(args).join();
-				htmldir.child("report.html").renameTo(htmldir.child("index.html"));
 			} else {
 				listener.getLogger().println("No reports found. Marking run with `test failure'");
 				run.setResult(onTestFailure);
@@ -342,7 +341,7 @@ public class QFTestConfigBuilder extends Builder implements SimpleBuildStep
 		//Publish HTML report
 		HtmlPublisher.publishReports(
 				run, workspace, listener, Collections.singletonList(new HtmlPublisherTarget(
-						"QF-Test Report", htmldir.getRemote(), "index.html", true, false, false
+						"QF-Test Report", htmldir.getRemote(), "report.html", true, false, false
 				)), this.getClass()
 		);
 	}


### PR DESCRIPTION
This broke our system of publishing the reports when we updated the plugin to 2.x
Renaming is not necessary as you can still publish the reports.
Renaming also breaks the internal links inside the *.html documents, as they have "report.html" as a static link.

There still is the "QF-Test Report" missing on the project page, but with this it at least works again.